### PR TITLE
Update runtime to Node 16

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: '14.x'
+        node-version: '16.x'
     - run: npm install --global @zeit/ncc
     - run: npm ci
     - run: npm run lint

--- a/action.yaml
+++ b/action.yaml
@@ -15,5 +15,5 @@ inputs:
     description: 'The remote password'
     default: ''
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
In accordance with the [deprecation process of Node 12 for GitHub Actions](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), this PR updates the action NodeJS runtime to the latest version.