### PR TITLE
Transitioning from Node 16 to Node 20

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: '16.x'
+        node-version: '20.x'
     - run: npm install --global @zeit/ncc
     - run: npm ci
     - run: npm run lint

--- a/action.yaml
+++ b/action.yaml
@@ -15,5 +15,5 @@ inputs:
     description: 'The remote password'
     default: ''
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
[GitHub is deprecating  Node 16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) by Spring 2024 and forces all action to run on Node 20.

This PR updates the runtime to the required one to avoid warnings being displayed now and be ready for the incoming changes.