### PR TITLE
Don't set action as failed in post run when file was already deleted

### DIFF
--- a/src/remove.ts
+++ b/src/remove.ts
@@ -8,10 +8,16 @@ async function main() {
     const netrc = path.resolve(os.homedir(), ".netrc");
     await fs.unlink(netrc);
   } catch (err) {
+    if (isErrnoException(err) && err.code == "ENOENT") return;
     if (err instanceof Error) {
       core.setFailed(err.message);
     }
   }
+}
+
+function isErrnoException(e: unknown): e is NodeJS.ErrnoException {
+  if ("code" in (e as any)) return true;
+  else return false;
 }
 
 main();


### PR DESCRIPTION
Fix #11 

When upgrading to v2, I had a workflow fail because it tried to delete the netrc file twice.

The action is added twice, since I need to add two different rules to the netrc file. In the post run, the second attempt to delete the file will currently fail:
<img width="1576" alt="Screenshot 2024-02-27 at 23 11 11" src="https://github.com/extractions/netrc/assets/48474670/35f602dd-7505-4129-886c-c9dc136651ff">

I added a small rule so the post-run doesn't fail if we can't delete the fail because it was already deleted.